### PR TITLE
adds functional options to courier creation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Run Mage
         uses: magefile/mage-action@v1
         with:
-          args: unitTest
+          args: race
       - name: Push Code Coverage
         uses: codecov/codecov-action@v1
         with:

--- a/client/client.go
+++ b/client/client.go
@@ -23,12 +23,12 @@ type MessageClient struct {
 	options       []grpc.DialOption
 }
 
-func NewMessageClient(info chan node.ResponseInfo, push chan message.Message, node chan map[string]node.Node, ctx context.Context, localAddress string, localPort string, options []grpc.DialOption) *MessageClient {
+func NewMessageClient(info chan node.ResponseInfo, node chan map[string]node.Node, ctx context.Context, localAddress string, localPort string, options []grpc.DialOption) *MessageClient {
 	c := MessageClient{
 		responseMap:   newResponseMap(),
 		subscriberMap: newSubscriberMap(),
 		infoChannel:   info,
-		pushChannel:   push,
+		pushChannel:   make(chan message.Message),
 		nodeChannel:   node,
 		gRPCContext:   ctx,
 		options:       options,

--- a/client/subscribermap.go
+++ b/client/subscribermap.go
@@ -21,6 +21,13 @@ func newSubscriberMap() *subscriberMap {
 	return &s
 }
 
+func (s *subscriberMap) TotalSubscribers(subject string) int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return len(s.subscribers[subject])
+}
+
 // Goes through a node's subscribed subjects and updates the subscriber map if
 // they aren't present under one of their subscribed subjects.
 func (s *subscriberMap) AddSubscriber(subscriber node.Node) {

--- a/client/subscribermap_test.go
+++ b/client/subscribermap_test.go
@@ -8,6 +8,25 @@ import (
 	"github.com/platform-edn/courier/node"
 )
 
+func TestSubscriberMap_TotalSubscribers(t *testing.T) {
+	subMap := newSubscriberMap()
+	subjects := []string{"sub", "sub1", "sub2"}
+	count := 10
+	nodes := mock.CreateTestNodes(count, &mock.TestNodeOptions{
+		SubscribedSubjects: subjects,
+	})
+
+	for _, n := range nodes {
+		subMap.AddSubscriber(*n)
+	}
+
+	total := subMap.TotalSubscribers("sub")
+
+	if total != count {
+		t.Fatalf("expected %v nodes to have subject sub but only %v did", count, total)
+	}
+}
+
 func TestSubscriberMap_AddSubscriber(t *testing.T) {
 	subMap := newSubscriberMap()
 	subjects := []string{"sub", "sub1", "sub2"}

--- a/courier_test.go
+++ b/courier_test.go
@@ -1,0 +1,27 @@
+package courier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/platform-edn/courier/mock"
+)
+
+func TestNewCourier(t *testing.T) {
+	sub := []string{"sub1", "sub2", "sub3"}
+	broad := []string{"broad1", "broad2", "broad3"}
+
+	nodes := mock.CreateTestNodes(5, &mock.TestNodeOptions{
+		SubscribedSubjects:  sub,
+		BroadcastedSubjects: broad,
+	})
+
+	store := mock.NewMockNodeStore(nodes...)
+	NewCourier(store,
+		Subscribes(sub...),
+		Broadcasts(broad...),
+		ListensOnAddress("test.com"),
+		ListensOnPort("3000"),
+		WithClientMessageContext(context.Background()),
+	)
+}

--- a/magefile.go
+++ b/magefile.go
@@ -52,8 +52,8 @@ func Proto() error {
 	return nil
 }
 
-// runs unit tests
-func UnitTest() error {
+// runs race tests
+func Race() error {
 	os.Chdir(baseDir)
 
 	err := sh.Run("go", "test", "-race", "-covermode=atomic", "-coverprofile=coverage.out", "./...")

--- a/observer/observer_test.go
+++ b/observer/observer_test.go
@@ -20,8 +20,6 @@ func TestStoreObserver_Start(t *testing.T) {
 
 	nodeChannel := observer.ListenChannel()
 
-	observer.Start()
-
 	timer := time.NewTimer(time.Second * 3)
 
 	select {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -11,10 +11,7 @@ import (
 func TestMessageProxy_Subscribe(t *testing.T) {
 	push := make(chan message.Message)
 	defer close(push)
-	quit := make(chan bool)
-	defer close(quit)
-
-	p := NewMessageProxy(push, quit)
+	p := NewMessageProxy(push)
 
 	sub := p.Subscribe("test")
 
@@ -31,17 +28,12 @@ func TestMessageProxy_Subscribe(t *testing.T) {
 	case <-time.After(time.Second * 1):
 		t.Fatal("timeout waitng on subscribe channel")
 	}
-
-	quit <- true
 }
 
 func TestSend(t *testing.T) {
 	push := make(chan message.Message)
 	defer close(push)
-	quit := make(chan bool)
-	defer close(quit)
-
-	p := NewMessageProxy(push, quit)
+	p := NewMessageProxy(push)
 
 	m1 := message.NewPubMessage(uuid.NewString(), "test", []byte("test"))
 	err := send(m1, p.Subscriptions)
@@ -64,17 +56,13 @@ func TestSend(t *testing.T) {
 	case <-time.After(time.Second * 1):
 		t.Fatal("timeout waitng on subscribe channel")
 	}
-
-	quit <- true
 }
 
 func TestMessageProxy_Start(t *testing.T) {
 	push := make(chan message.Message)
 	defer close(push)
-	quit := make(chan bool)
-	defer close(quit)
 
-	p := NewMessageProxy(push, quit)
+	p := NewMessageProxy(push)
 
 	sub := p.Subscribe("test")
 
@@ -94,6 +82,4 @@ func TestMessageProxy_Start(t *testing.T) {
 	case <-time.After(time.Second * 1):
 		t.Fatal("timeout waitng on subscribe channel")
 	}
-
-	quit <- true
 }

--- a/server/server.go
+++ b/server/server.go
@@ -9,18 +9,26 @@ import (
 )
 
 type MessageServer struct {
-	pushChannel chan message.Message
-	infoChannel chan node.ResponseInfo
+	pushChannel     chan message.Message
+	responseChannel chan node.ResponseInfo
 	proto.UnimplementedMessageServerServer
 }
 
-func NewMessageServer(push chan message.Message, info chan node.ResponseInfo) *MessageServer {
+func NewMessageServer() *MessageServer {
 	m := MessageServer{
-		pushChannel: push,
-		infoChannel: info,
+		pushChannel:     make(chan message.Message),
+		responseChannel: make(chan node.ResponseInfo),
 	}
 
 	return &m
+}
+
+func (m *MessageServer) PushChannel() chan message.Message {
+	return m.pushChannel
+}
+
+func (m *MessageServer) ResponseChannel() chan node.ResponseInfo {
+	return m.responseChannel
 }
 
 func (m *MessageServer) PublishMessage(ctx context.Context, request *proto.PublishMessageRequest) (*proto.PublishMessageResponse, error) {
@@ -42,7 +50,7 @@ func (m *MessageServer) RequestMessage(ctx context.Context, request *proto.Reque
 	}
 
 	m.pushChannel <- req
-	m.infoChannel <- info
+	m.responseChannel <- info
 
 	response := proto.RequestMessageResponse{}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,9 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/platform-edn/courier/message"
 	"github.com/platform-edn/courier/mock"
-	"github.com/platform-edn/courier/node"
 	"github.com/platform-edn/courier/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -25,10 +23,8 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 }
 
 func TestMessageServer_PublishMessage(t *testing.T) {
-	push := make(chan message.Message)
-	info := make(chan node.ResponseInfo)
-
-	server := NewMessageServer(push, info)
+	server := NewMessageServer()
+	push := server.PushChannel()
 
 	startTestServer(server)
 
@@ -61,10 +57,8 @@ func TestMessageServer_PublishMessage(t *testing.T) {
 }
 
 func TestMessageServer_ResponseMessage(t *testing.T) {
-	push := make(chan message.Message)
-	info := make(chan node.ResponseInfo)
-
-	server := NewMessageServer(push, info)
+	server := NewMessageServer()
+	push := server.PushChannel()
 
 	startTestServer(server)
 
@@ -97,10 +91,9 @@ func TestMessageServer_ResponseMessage(t *testing.T) {
 }
 
 func TestMessageServer_RequestMessage(t *testing.T) {
-	push := make(chan message.Message)
-	info := make(chan node.ResponseInfo)
-
-	server := NewMessageServer(push, info)
+	server := NewMessageServer()
+	push := server.PushChannel()
+	info := server.ResponseChannel()
 
 	startTestServer(server)
 


### PR DESCRIPTION
# Description

Instead of passing in a bunch of parameters, we now accept functions when creating a new Courier object.  This allows for future changes to be made with out breaking backwards compatibility as well as adds ability for default options.  AN example would be 

```
	NewCourier(store,
		Subscribes([]string{"sub1", "sub2", "sub3"}...),
		Broadcasts([]string{"broad1", "broad2", "broad3"}...),
		ListensOnAddress("test.com"),
		ListensOnPort("3000"),
		WithClientMessageContext(context.Background()),
	)
```