### PR TITLE
Create client node

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,15 +31,21 @@ func listenForResponseInfo(responses chan ResponseInfo, respMap ResponseMapper) 
 }
 
 // listenForNewNodes takes nodes passed through a channel and adds them to a NodeMapper and SubMapper
-func listenForNewNodes(nodeChannel chan Node, nodeMap NodeMapper, subMap SubMapper) {
+func listenForNewNodes(nodeChannel chan Node, nodeMap ClientNodeMapper, subMap SubMapper, currentId string, options ...grpc.DialOption) {
 	for n := range nodeChannel {
-		nodeMap.Add(n)
+		cn, err := newClientNode(n, currentId, options...)
+		if err != nil {
+			log.Printf("skipping %s, couldn't create client node: %s", n.Id, err)
+			continue
+		}
+
+		nodeMap.Add(*cn)
 		subMap.Add(n.Id, n.SubscribedSubjects...)
 	}
 }
 
 // listenForStaleNodes takes nodes passed in and removes them from a NodeMapper and SubMapper
-func listenForStaleNodes(staleChannel chan Node, nodeMap NodeMapper, subMap SubMapper) {
+func listenForStaleNodes(staleChannel chan Node, nodeMap ClientNodeMapper, subMap SubMapper) {
 	for n := range staleChannel {
 		nodeMap.Remove(n.Id)
 		subMap.Remove(n.Id, n.SubscribedSubjects...)
@@ -81,8 +87,8 @@ func generateIdsByMessage(messageId string, respMap ResponseMapper) (<-chan stri
 }
 
 // idToNodes takes a channel of ids and returns a channel of nodes based on the ids
-func idToNodes(in <-chan string, nodeMap NodeMapper) <-chan Node {
-	out := make(chan Node)
+func idToClientNodes(in <-chan string, nodeMap ClientNodeMapper) <-chan clientNode {
+	out := make(chan clientNode)
 	go func() {
 		for id := range in {
 			n, exist := nodeMap.Node(id)
@@ -99,42 +105,16 @@ func idToNodes(in <-chan string, nodeMap NodeMapper) <-chan Node {
 	return out
 }
 
-// nodeToCourierClients takes a channel of nodes and returns a channel of courierClients
-func nodeToCourierClients(in <-chan Node, id string, options ...grpc.DialOption) <-chan courierClient {
-	out := make(chan courierClient)
-	go func() {
-		for n := range in {
-			conn, err := grpc.Dial(fmt.Sprintf("%s:%s", n.Address, n.Port), options...)
-			if err != nil {
-				log.Printf("skipping node %s - could not create connection at %s: %s", n.Id, fmt.Sprintf("%s:%s", n.Address, n.Port), err)
-				continue
-			}
-
-			cc := courierClient{
-				client:     proto.NewMessageServerClient(conn),
-				connection: *conn,
-				currentId:  id,
-				receiver:   n,
-			}
-
-			out <- cc
-		}
-		close(out)
-	}()
-
-	return out
-}
-
 // fanMessageAttempts takes a channel of courierClients and creates a goroutine for each to attempt a   Returns a channel that will return nodes that unsuccessfully sent a message
-func fanMessageAttempts(in <-chan courierClient, ctx context.Context, metadata attemptMetadata, msg Message, send sendFunc) chan Node {
+func fanMessageAttempts(in <-chan clientNode, ctx context.Context, metadata attemptMetadata, msg Message, send sendFunc) chan Node {
 	out := make(chan Node)
 
 	go func() {
 		wg := &sync.WaitGroup{}
 
-		for client := range in {
+		for n := range in {
 			wg.Add(1)
-			go attemptMessage(ctx, client, metadata, msg, send, out, wg)
+			go attemptMessage(ctx, n, metadata, msg, send, out, wg)
 		}
 
 		wg.Wait()
@@ -145,7 +125,7 @@ func fanMessageAttempts(in <-chan courierClient, ctx context.Context, metadata a
 }
 
 // attemptMessage takes a send function and attempts it until it succeeds or has reached maxAttempts.  Waits between attempts depends on the given interval
-func attemptMessage(ctx context.Context, client courierClient, metadata attemptMetadata, msg Message, send sendFunc, nchan chan Node, wg *sync.WaitGroup) {
+func attemptMessage(ctx context.Context, client clientNode, metadata attemptMetadata, msg Message, send sendFunc, nchan chan Node, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	attempts := 0
@@ -160,7 +140,7 @@ func attemptMessage(ctx context.Context, client courierClient, metadata attemptM
 		return
 	}
 
-	nchan <- client.receiver
+	nchan <- client.Node
 }
 
 // forwardFailedConnections takes a channel of nodes and sends them through a stale channel as well as a failed connection channel.  Returns a bool channel that receives true when it's done
@@ -181,9 +161,9 @@ func forwardFailedConnections(in <-chan Node, fchan chan Node, schan chan Node) 
 	return out
 }
 
-type sendFunc func(context.Context, Message, courierClient) error
+type sendFunc func(context.Context, Message, clientNode) error
 
-func sendPublishMessage(ctx context.Context, m Message, cc courierClient) error {
+func sendPublishMessage(ctx context.Context, m Message, cc clientNode) error {
 	if m.Type != PubMessage {
 		return fmt.Errorf("message type must be of type PublishMessage")
 	}
@@ -202,7 +182,7 @@ func sendPublishMessage(ctx context.Context, m Message, cc courierClient) error 
 	return nil
 }
 
-func sendRequestMessage(ctx context.Context, m Message, cc courierClient) error {
+func sendRequestMessage(ctx context.Context, m Message, cc clientNode) error {
 	if m.Type != ReqMessage {
 		return fmt.Errorf("message type must be of type RequestMessage")
 	}
@@ -210,7 +190,7 @@ func sendRequestMessage(ctx context.Context, m Message, cc courierClient) error 
 	_, err := cc.client.RequestMessage(ctx, &proto.RequestMessageRequest{
 		Message: &proto.RequestMessage{
 			Id:      m.Id,
-			NodeId:  cc.receiver.Id,
+			NodeId:  cc.Id,
 			Subject: m.Subject,
 			Content: m.Content,
 		},
@@ -222,7 +202,7 @@ func sendRequestMessage(ctx context.Context, m Message, cc courierClient) error 
 	return nil
 }
 
-func sendResponseMessage(ctx context.Context, m Message, cc courierClient) error {
+func sendResponseMessage(ctx context.Context, m Message, cc clientNode) error {
 	if m.Type != RespMessage {
 		return fmt.Errorf("message type must be of type ResponseMessage")
 	}

--- a/client.go
+++ b/client.go
@@ -11,13 +11,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-type courierClient struct {
-	client     proto.MessageServerClient
-	connection grpc.ClientConn
-	currentId  string
-	receiver   Node
-}
-
 type attemptMetadata struct {
 	maxAttempts  int
 	waitInterval time.Duration

--- a/client_node.go
+++ b/client_node.go
@@ -1,0 +1,31 @@
+package courier
+
+import (
+	"fmt"
+
+	"github.com/platform-edn/courier/proto"
+	"google.golang.org/grpc"
+)
+
+type clientNode struct {
+	Node
+	client     proto.MessageServerClient
+	connection grpc.ClientConn
+	currentId  string
+}
+
+func newClientNode(node Node, currrentId string, options ...grpc.DialOption) (*clientNode, error) {
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", node.Address, node.Port), options...)
+	if err != nil {
+		return nil, fmt.Errorf("could not create connection at %s: %s", fmt.Sprintf("%s:%s", node.Address, node.Port), err)
+	}
+
+	n := clientNode{
+		Node:       node,
+		client:     proto.NewMessageServerClient(conn),
+		connection: *conn,
+		currentId:  currrentId,
+	}
+
+	return &n, nil
+}

--- a/client_node_map.go
+++ b/client_node_map.go
@@ -1,0 +1,52 @@
+package courier
+
+type ClientNodeMapper interface {
+	Node(string) (clientNode, bool)
+	Add(clientNode)
+	Remove(string)
+	Length() int
+}
+
+type clientNodeMap struct {
+	nodes map[string]clientNode
+	lock  Locker
+}
+
+func newClientNodeMap() *clientNodeMap {
+	nm := clientNodeMap{
+		nodes: map[string]clientNode{},
+		lock:  NewTicketLock(),
+	}
+
+	return &nm
+}
+
+func (nm *clientNodeMap) Node(id string) (clientNode, bool) {
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	n, exist := nm.nodes[id]
+
+	return n, exist
+}
+
+func (nm *clientNodeMap) Add(n clientNode) {
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	nm.nodes[n.Id] = n
+}
+
+func (nm *clientNodeMap) Remove(id string) {
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	delete(nm.nodes, id)
+}
+
+func (nm *clientNodeMap) Length() int {
+	nm.lock.Lock()
+	defer nm.lock.Unlock()
+
+	return len(nm.nodes)
+}

--- a/client_node_map_test.go
+++ b/client_node_map_test.go
@@ -1,0 +1,93 @@
+package courier
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+func TestClientNodeMap_Nodes(t *testing.T) {
+	l := 10
+	nodes := CreateTestNodes(l, &TestNodeOptions{})
+	b := newClientNodeMap()
+
+	for _, n := range nodes {
+		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		if err != nil {
+			t.Fatalf("could not create client node: %s", err)
+		}
+		b.Add(*cn)
+	}
+
+	for _, n := range nodes {
+		_, exist := b.nodes[n.Id]
+		if !exist {
+			t.Fatalf("expected node with id %s to exist but it didn't", n.Id)
+		}
+	}
+}
+
+func TestClientNodeMap_Add(t *testing.T) {
+	b := newClientNodeMap()
+	l := 10
+	nodes := CreateTestNodes(l, &TestNodeOptions{})
+
+	for _, n := range nodes {
+		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		if err != nil {
+			t.Fatalf("could not create client node: %s", err)
+		}
+		b.Add(*cn)
+	}
+
+	bl := b.Length()
+
+	if bl != l {
+		t.Fatalf("expected length to be %v but got %v", l, bl)
+	}
+}
+
+func TestClientNodeMap_Remove(t *testing.T) {
+	b := newClientNodeMap()
+	l := 10
+	nodes := CreateTestNodes(l, &TestNodeOptions{})
+
+	for _, n := range nodes {
+		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		if err != nil {
+			t.Fatalf("could not create client node: %s", err)
+		}
+		b.Add(*cn)
+	}
+
+	for _, n := range nodes {
+		b.Remove(n.Id)
+	}
+
+	bl := b.Length()
+
+	if bl != 0 {
+		t.Fatalf("expected length to be %v but got %v", 0, bl)
+	}
+}
+
+func TestClientNodeMap_Length(t *testing.T) {
+	b := newClientNodeMap()
+	l := 10
+	nodes := CreateTestNodes(l, &TestNodeOptions{})
+
+	for _, n := range nodes {
+		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		if err != nil {
+			t.Fatalf("could not create client node: %s", err)
+		}
+		b.Add(*cn)
+	}
+
+	bl := b.Length()
+
+	if bl != len(b.nodes) {
+		t.Fatalf("expected length to be %v but got %v", len(b.nodes), bl)
+	}
+}

--- a/client_node_test.go
+++ b/client_node_test.go
@@ -1,0 +1,47 @@
+package courier
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+/**************************************************************
+Expected Outcomes:
+- should fail if options are incorrect for creating a a grpc client connection
+**************************************************************/
+func TestNewClientNode(t *testing.T) {
+	type test struct {
+		port            string
+		options         []grpc.DialOption
+		expectedFailure bool
+	}
+
+	tests := []test{
+		{
+			options:         []grpc.DialOption{grpc.WithInsecure()},
+			expectedFailure: false,
+		},
+		{
+			options:         []grpc.DialOption{},
+			expectedFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		n := CreateTestNodes(1, &TestNodeOptions{})[0]
+		n.Port = tc.port
+		_, err := newClientNode(*n, uuid.NewString(), tc.options...)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("expected newClientNode to pass but it failed: %s", err)
+		}
+
+		if tc.expectedFailure {
+			t.Fatal("expected newClientNode to fail but it passed")
+		}
+	}
+}


### PR DESCRIPTION
moves grpc Client creation when new nodes are added to the client routines.  Refactors weird courierClient to a clientNode that makes way more sense.  Adds new mapper.  Adds more testing!!!!