### PR TITLE
changes attemptMessage to accept an interface

### DIFF
--- a/client_node_test.go
+++ b/client_node_test.go
@@ -1,10 +1,12 @@
 package courier
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 /**************************************************************
@@ -42,6 +44,195 @@ func TestNewClientNode(t *testing.T) {
 
 		if tc.expectedFailure {
 			t.Fatal("expected newClientNode to fail but it passed")
+		}
+	}
+}
+
+/**************************************************************
+Expected Outcomes:
+- should send a publish message to a grpc server successfully
+- returns error if the message was not sent successfully
+- returns error if message is not a publish message
+**************************************************************/
+func TestClientNode_SendPublishMessage(t *testing.T) {
+	type test struct {
+		m               Message
+		serverFailure   bool
+		expectedFailure bool
+	}
+
+	tests := []test{
+		{
+			m:               NewPubMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   true,
+			expectedFailure: true,
+		},
+		{
+			m:               NewPubMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: false,
+		},
+		{
+			m:               NewReqMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		server := NewMockServer(bufconn.Listen(1024*1024), tc.serverFailure)
+		client, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not creat client for server: %s", err)
+		}
+		defer conn.Close()
+
+		cc := clientNode{
+			client:     client,
+			connection: *conn,
+			currentId:  uuid.NewString(),
+			Node:       *CreateTestNodes(1, &TestNodeOptions{})[0],
+		}
+
+		err = cc.sendPublishMessage(context.Background(), tc.m)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not send message: %s", err)
+		}
+
+		if tc.expectedFailure {
+			t.Fatalf("sendPublishMessage was expected to fail but it didn't")
+		}
+	}
+}
+
+/**************************************************************
+Expected Outcomes:
+- should send a request message to a grpc server successfully
+- returns error if the message was not sent successfully
+- returns error if message is not a publish message
+**************************************************************/
+func TestClientNode_SendRequestMessage(t *testing.T) {
+	type test struct {
+		m               Message
+		serverFailure   bool
+		expectedFailure bool
+	}
+
+	tests := []test{
+		{
+			m:               NewReqMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   true,
+			expectedFailure: true,
+		},
+		{
+			m:               NewReqMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: false,
+		},
+		{
+			m:               NewPubMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		server := NewMockServer(bufconn.Listen(1024*1024), tc.serverFailure)
+		client, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not creat client for server: %s", err)
+		}
+		defer conn.Close()
+
+		cc := clientNode{
+			client:     client,
+			connection: *conn,
+			currentId:  uuid.NewString(),
+			Node:       *CreateTestNodes(1, &TestNodeOptions{})[0],
+		}
+
+		err = cc.sendRequestMessage(context.Background(), tc.m)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not send message: %s", err)
+		}
+
+		if tc.expectedFailure {
+			t.Fatalf("sendRequestMessage was expected to fail but it didn't")
+		}
+	}
+}
+
+/**************************************************************
+Expected Outcomes:
+- should send a request message to a grpc server successfully
+- returns error if the message was not sent successfully
+- returns error if message is not a publish message
+**************************************************************/
+func TestClientNode_SendResponseMessage(t *testing.T) {
+	type test struct {
+		m               Message
+		serverFailure   bool
+		expectedFailure bool
+	}
+
+	tests := []test{
+		{
+			m:               NewRespMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   true,
+			expectedFailure: true,
+		},
+		{
+			m:               NewRespMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: false,
+		},
+		{
+			m:               NewPubMessage(uuid.NewString(), "test", []byte("test")),
+			serverFailure:   false,
+			expectedFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		server := NewMockServer(bufconn.Listen(1024*1024), tc.serverFailure)
+		client, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not creat client for server: %s", err)
+		}
+		defer conn.Close()
+
+		cc := clientNode{
+			client:     client,
+			connection: *conn,
+			currentId:  uuid.NewString(),
+			Node:       *CreateTestNodes(1, &TestNodeOptions{})[0],
+		}
+
+		err = cc.sendResponseMessage(context.Background(), tc.m)
+		if err != nil {
+			if tc.expectedFailure {
+				continue
+			}
+			t.Fatalf("could not send message: %s", err)
+		}
+
+		if tc.expectedFailure {
+			t.Fatalf("sendResponseMessage was expected to fail but it didn't")
 		}
 	}
 }

--- a/courier.go
+++ b/courier.go
@@ -195,7 +195,7 @@ func (c *Courier) Publish(ctx context.Context, m Message) error {
 	}
 
 	cnodes := idToClientNodes(ids, c.clientNodes)
-	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m, sendPublishMessage)
+	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m)
 	done := forwardFailedConnections(failed, c.failedConnectionChannel, c.staleNodeChannel)
 
 	<-done
@@ -214,7 +214,7 @@ func (c *Courier) Request(ctx context.Context, m Message) error {
 	}
 
 	cnodes := idToClientNodes(ids, c.clientNodes)
-	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m, sendRequestMessage)
+	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m)
 	done := forwardFailedConnections(failed, c.failedConnectionChannel, c.staleNodeChannel)
 
 	<-done
@@ -233,7 +233,7 @@ func (c *Courier) Response(ctx context.Context, m Message) error {
 	}
 
 	cnodes := idToClientNodes(ids, c.clientNodes)
-	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m, sendResponseMessage)
+	failed := fanMessageAttempts(cnodes, ctx, c.attemptMetadata, m)
 	done := forwardFailedConnections(failed, c.failedConnectionChannel, c.staleNodeChannel)
 
 	<-done


### PR DESCRIPTION
#25 makes the client logic for grpc bundled into a single struct type.  I wanted to take this one step further and create an interface so that we could easily switch from grpc to something in the future.  All we would need to do is update the logic inside of clientNode and it won't impact the rest of the system