### PR TITLE
Add noder interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,20 +35,20 @@ func listenForNewNodes(nodeChannel chan Node, nodeMap ClientNodeMapper, subMap S
 	for n := range nodeChannel {
 		cn, err := newClientNode(n, currentId, options...)
 		if err != nil {
-			log.Printf("skipping %s, couldn't create client node: %s", n.Id, err)
+			log.Printf("skipping %s, couldn't create client node: %s", n.id, err)
 			continue
 		}
 
 		nodeMap.Add(*cn)
-		subMap.Add(n.Id, n.SubscribedSubjects...)
+		subMap.Add(n.id, n.subscribedSubjects...)
 	}
 }
 
 // listenForStaleNodes takes nodes passed in and removes them from a NodeMapper and SubMapper
 func listenForStaleNodes(staleChannel chan Node, nodeMap ClientNodeMapper, subMap SubMapper) {
 	for n := range staleChannel {
-		nodeMap.Remove(n.Id)
-		subMap.Remove(n.Id, n.SubscribedSubjects...)
+		nodeMap.Remove(n.id)
+		subMap.Remove(n.id, n.subscribedSubjects...)
 	}
 }
 
@@ -149,7 +149,7 @@ func forwardFailedConnections(in <-chan Node, fchan chan Node, schan chan Node) 
 
 	go func() {
 		for n := range in {
-			log.Printf("failed creating connection to %s:%s - will now be removing and blacklisting %s\n", n.Address, n.Port, n.Id)
+			log.Printf("failed creating connection to %s:%s - will now be removing and blacklisting %s\n", n.address, n.port, n.id)
 
 			schan <- n
 			fchan <- n

--- a/client_node.go
+++ b/client_node.go
@@ -15,9 +15,9 @@ type clientNode struct {
 }
 
 func newClientNode(node Node, currrentId string, options ...grpc.DialOption) (*clientNode, error) {
-	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", node.Address, node.Port), options...)
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", node.address, node.port), options...)
 	if err != nil {
-		return nil, fmt.Errorf("could not create connection at %s: %s", fmt.Sprintf("%s:%s", node.Address, node.Port), err)
+		return nil, fmt.Errorf("could not create connection at %s: %s", fmt.Sprintf("%s:%s", node.address, node.port), err)
 	}
 
 	n := clientNode{
@@ -74,7 +74,7 @@ func (c *clientNode) sendRequestMessage(ctx context.Context, m Message) error {
 	_, err := proto.NewMessageServerClient(c.connection).RequestMessage(ctx, &proto.RequestMessageRequest{
 		Message: &proto.RequestMessage{
 			Id:      m.Id,
-			NodeId:  c.Id,
+			NodeId:  c.id,
 			Subject: m.Subject,
 			Content: m.Content,
 		},

--- a/client_node_map.go
+++ b/client_node_map.go
@@ -34,7 +34,7 @@ func (nm *clientNodeMap) Add(n clientNode) {
 	nm.lock.Lock()
 	defer nm.lock.Unlock()
 
-	nm.nodes[n.Id] = n
+	nm.nodes[n.id] = n
 }
 
 func (nm *clientNodeMap) Remove(id string) {

--- a/client_node_map_test.go
+++ b/client_node_map_test.go
@@ -21,9 +21,9 @@ func TestClientNodeMap_Nodes(t *testing.T) {
 	}
 
 	for _, n := range nodes {
-		_, exist := b.nodes[n.Id]
+		_, exist := b.nodes[n.id]
 		if !exist {
-			t.Fatalf("expected node with id %s to exist but it didn't", n.Id)
+			t.Fatalf("expected node with id %s to exist but it didn't", n.id)
 		}
 	}
 }
@@ -62,7 +62,7 @@ func TestClientNodeMap_Remove(t *testing.T) {
 	}
 
 	for _, n := range nodes {
-		b.Remove(n.Id)
+		b.Remove(n.id)
 	}
 
 	bl := b.Length()

--- a/client_node_test.go
+++ b/client_node_test.go
@@ -33,7 +33,7 @@ func TestNewClientNode(t *testing.T) {
 
 	for _, tc := range tests {
 		n := CreateTestNodes(1, &TestNodeOptions{})[0]
-		n.Port = tc.port
+		n.port = tc.port
 		_, err := newClientNode(*n, uuid.NewString(), tc.options...)
 		if err != nil {
 			if tc.expectedFailure {

--- a/client_test.go
+++ b/client_test.go
@@ -105,8 +105,8 @@ func TestListenForNewNodes(t *testing.T) {
 
 		checkSubMap := func(nodes []*Node, smap *subscriberMap) bool {
 			for _, n := range nodes {
-				for _, subject := range n.SubscribedSubjects {
-					exist := smap.CheckForSubscriber(subject, n.Id)
+				for _, subject := range n.subscribedSubjects {
+					exist := smap.CheckForSubscriber(subject, n.id)
 					if !exist {
 						return false
 					}
@@ -163,7 +163,7 @@ func TestListenForStaleNodes(t *testing.T) {
 		schan := make(chan Node)
 
 		for _, n := range nodes {
-			subMap.Add(n.Id, n.SubscribedSubjects...)
+			subMap.Add(n.id, n.subscribedSubjects...)
 			nodeMap.Add(clientNode{
 				Node: *n,
 			})
@@ -180,8 +180,8 @@ func TestListenForStaleNodes(t *testing.T) {
 
 		checkSubMap := func(nodes []*Node, smap *subscriberMap) bool {
 			for _, n := range nodes {
-				for _, subject := range n.SubscribedSubjects {
-					exist := smap.CheckForSubscriber(subject, n.Id)
+				for _, subject := range n.subscribedSubjects {
+					exist := smap.CheckForSubscriber(subject, n.id)
 					if exist {
 						return false
 					}
@@ -361,7 +361,7 @@ func TestIdToClientNodes(t *testing.T) {
 				t.Fatalf("could not create clientNode: %s", err)
 			}
 			nodeMap.Add(*cn)
-			ids = append(ids, n.Id)
+			ids = append(ids, n.id)
 		}
 
 		for i := 0; i < tc.invalidCount; i++ {

--- a/courier.go
+++ b/courier.go
@@ -87,7 +87,7 @@ type Courier struct {
 	Observer                Observer
 	attemptMetadata         attemptMetadata
 	DialOptions             []grpc.DialOption
-	observerChannel         chan []Node
+	observerChannel         chan []Noder
 	newNodeChannel          chan Node
 	staleNodeChannel        chan Node
 	failedConnectionChannel chan Node
@@ -115,7 +115,7 @@ func NewCourier(options ...CourierOption) (*Courier, error) {
 		},
 		DialOptions:             []grpc.DialOption{},
 		Observer:                nil,
-		observerChannel:         make(chan []Node),
+		observerChannel:         make(chan []Noder),
 		newNodeChannel:          make(chan Node),
 		staleNodeChannel:        make(chan Node),
 		failedConnectionChannel: make(chan Node),

--- a/courier_test.go
+++ b/courier_test.go
@@ -29,7 +29,7 @@ func TestNewCourier(t *testing.T) {
 
 	tests := []test{
 		{
-			observer:        newMockObserver(make(chan []Node), false),
+			observer:        newMockObserver(make(chan []Noder), false),
 			dialOptions:     []grpc.DialOption{grpc.WithInsecure()},
 			hostname:        "test",
 			port:            "3000",
@@ -45,7 +45,7 @@ func TestNewCourier(t *testing.T) {
 			expectedFailure: true,
 		},
 		{
-			observer:        newMockObserver(make(chan []Node), false),
+			observer:        newMockObserver(make(chan []Noder), false),
 			dialOptions:     []grpc.DialOption{grpc.WithInsecure()},
 			hostname:        "",
 			port:            "3002",
@@ -53,7 +53,7 @@ func TestNewCourier(t *testing.T) {
 			expectedFailure: false,
 		},
 		{
-			observer:        newMockObserver(make(chan []Node), false),
+			observer:        newMockObserver(make(chan []Noder), false),
 			dialOptions:     []grpc.DialOption{},
 			hostname:        "test",
 			port:            "3003",
@@ -61,7 +61,7 @@ func TestNewCourier(t *testing.T) {
 			expectedFailure: false,
 		},
 		{
-			observer:        newMockObserver(make(chan []Node), true),
+			observer:        newMockObserver(make(chan []Noder), true),
 			dialOptions:     []grpc.DialOption{grpc.WithInsecure()},
 			hostname:        "test",
 			port:            "3004",
@@ -126,17 +126,17 @@ func TestCourier_Start(t *testing.T) {
 	tests := []test{
 		{
 			port:            "asdfasdf",
-			observer:        newMockObserver(make(chan []Node), false),
+			observer:        newMockObserver(make(chan []Noder), false),
 			expectedFailure: true,
 		},
 		{
 			port:            "3000",
-			observer:        newMockObserver(make(chan []Node), true),
+			observer:        newMockObserver(make(chan []Noder), true),
 			expectedFailure: true,
 		},
 		{
 			port:            "3001",
-			observer:        newMockObserver(make(chan []Node), false),
+			observer:        newMockObserver(make(chan []Noder), false),
 			expectedFailure: false,
 		},
 	}
@@ -146,7 +146,7 @@ func TestCourier_Start(t *testing.T) {
 		broad := []string{"broad1", "broad2", "broad3"}
 
 		c, err := NewCourier(
-			WithObserver(newMockObserver(make(chan []Node), false)),
+			WithObserver(newMockObserver(make(chan []Noder), false)),
 			Subscribes(sub...),
 			Broadcasts(broad...),
 			WithHostname("test.com"),
@@ -224,7 +224,7 @@ func TestCourier_Publish(t *testing.T) {
 		m := tc.messageFunc(uuid.NewString(), tc.nodeSubject, []byte("test"))
 		nodes := CreateTestNodes(tc.nodeCount, &TestNodeOptions{})
 		c, err := NewCourier(
-			WithObserver(newMockObserver(make(chan []Node), false)),
+			WithObserver(newMockObserver(make(chan []Noder), false)),
 			WithHostname("test.com"),
 			WithPort(tc.port),
 			WithDialOptions(grpc.WithInsecure()),
@@ -237,7 +237,7 @@ func TestCourier_Publish(t *testing.T) {
 		}
 
 		for _, n := range nodes {
-			c.clientSubscribers.Add(n.Id, tc.nodeSubject)
+			c.clientSubscribers.Add(n.id, tc.nodeSubject)
 			_, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
 			if err != nil {
 				t.Fatalf("could not create grpc client: %s", err)
@@ -336,7 +336,7 @@ func TestCourier_Request(t *testing.T) {
 		m := tc.messageFunc(uuid.NewString(), tc.messageSubject, []byte("test"))
 		nodes := CreateTestNodes(tc.nodeCount, &TestNodeOptions{})
 		c, err := NewCourier(
-			WithObserver(newMockObserver(make(chan []Node), false)),
+			WithObserver(newMockObserver(make(chan []Noder), false)),
 			WithHostname("test.com"),
 			WithPort(tc.port),
 			WithDialOptions(grpc.WithInsecure()),
@@ -349,7 +349,7 @@ func TestCourier_Request(t *testing.T) {
 		}
 
 		for _, n := range nodes {
-			c.clientSubscribers.Add(n.Id, tc.nodeSubject)
+			c.clientSubscribers.Add(n.id, tc.nodeSubject)
 			_, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
 			if err != nil {
 				t.Fatalf("could not create grpc client: %s", err)
@@ -443,7 +443,7 @@ func TestCourier_Response(t *testing.T) {
 		server := NewMockServer(bufconn.Listen(1024*1024), false)
 		nodes := CreateTestNodes(tc.nodeCount, &TestNodeOptions{})
 		c, err := NewCourier(
-			WithObserver(newMockObserver(make(chan []Node), false)),
+			WithObserver(newMockObserver(make(chan []Noder), false)),
 			WithHostname("test.com"),
 			WithPort(tc.port),
 			WithDialOptions(grpc.WithInsecure()),
@@ -458,7 +458,7 @@ func TestCourier_Response(t *testing.T) {
 		var messageList []Message
 
 		for _, n := range nodes {
-			c.clientSubscribers.Add(n.Id, tc.nodeSubject)
+			c.clientSubscribers.Add(n.id, tc.nodeSubject)
 			_, conn, err := NewLocalGRPCClient("bufnet", server.BufDialer)
 			if err != nil {
 				t.Fatalf("could not create grpc client: %s", err)
@@ -477,12 +477,12 @@ func TestCourier_Response(t *testing.T) {
 			if tc.badMessageId {
 				c.responses.Push(ResponseInfo{
 					MessageId: "badId",
-					NodeId:    n.Id,
+					NodeId:    n.id,
 				})
 			} else {
 				c.responses.Push(ResponseInfo{
 					MessageId: m.Id,
-					NodeId:    n.Id,
+					NodeId:    n.id,
 				})
 			}
 
@@ -527,7 +527,7 @@ Expected Outcomes:
 **************************************************************/
 func TestCourier_Subscribe(t *testing.T) {
 	c, err := NewCourier(
-		WithObserver(newMockObserver(make(chan []Node), false)),
+		WithObserver(newMockObserver(make(chan []Noder), false)),
 		WithHostname("test.com"),
 		WithPort("3008"),
 		WithDialOptions(grpc.WithInsecure()),

--- a/node.go
+++ b/node.go
@@ -1,21 +1,49 @@
 package courier
 
+type Noder interface {
+	Id() string
+	Address() string
+	Subscribed() []string
+	Broadcasted() []string
+	Port() string
+}
+
 type Node struct {
-	Id                  string
-	Address             string
-	Port                string
-	SubscribedSubjects  []string
-	BroadcastedSubjects []string
+	id                  string
+	address             string
+	port                string
+	subscribedSubjects  []string
+	broadcastedSubjects []string
 }
 
 func NewNode(id string, address string, port string, subscribed []string, broadcasted []string) *Node {
 	n := Node{
-		Id:                  id,
-		Address:             address,
-		Port:                port,
-		SubscribedSubjects:  subscribed,
-		BroadcastedSubjects: broadcasted,
+		id:                  id,
+		address:             address,
+		port:                port,
+		subscribedSubjects:  subscribed,
+		broadcastedSubjects: broadcasted,
 	}
 
 	return &n
+}
+
+func (n *Node) Id() string {
+	return n.id
+}
+
+func (n *Node) Address() string {
+	return n.address
+}
+
+func (n *Node) Port() string {
+	return n.port
+}
+
+func (n *Node) Subscribed() []string {
+	return n.subscribedSubjects
+}
+
+func (n *Node) Broadcasted() []string {
+	return n.broadcastedSubjects
 }

--- a/nodemap.go
+++ b/nodemap.go
@@ -47,7 +47,7 @@ func (nm *NodeMap) Add(n Node) {
 	nm.lock.Lock()
 	defer nm.lock.Unlock()
 
-	nm.nodes[n.Id] = n
+	nm.nodes[n.id] = n
 }
 
 func (nm *NodeMap) Remove(id string) {
@@ -65,7 +65,7 @@ func (nm *NodeMap) Update(nodes ...Node) {
 
 	for _, n := range nodes {
 
-		new[n.Id] = n
+		new[n.id] = n
 	}
 
 	nm.nodes = new

--- a/nodemap_test.go
+++ b/nodemap_test.go
@@ -10,9 +10,9 @@ func TestNodeMap_Nodes(t *testing.T) {
 	b := NewNodeMap(RemovePointers(nodes)...)
 
 	for _, n := range nodes {
-		_, exist := b.nodes[n.Id]
+		_, exist := b.nodes[n.id]
 		if !exist {
-			t.Fatalf("expected node with id %s to exist but it didn't", n.Id)
+			t.Fatalf("expected node with id %s to exist but it didn't", n.id)
 		}
 	}
 }
@@ -43,7 +43,7 @@ func TestNodeMap_Remove(t *testing.T) {
 	}
 
 	for _, n := range nodes {
-		b.Remove(n.Id)
+		b.Remove(n.id)
 	}
 
 	bl := b.Length()

--- a/register_test.go
+++ b/register_test.go
@@ -45,7 +45,7 @@ func TestRegisterNodes(t *testing.T) {
 		nodes := append(bln, cln...)
 		nodes = append(nodes, nn...)
 		fn := CreateTestNodes(1, &TestNodeOptions{})[0]
-		ochan := make(chan []Node)
+		ochan := make(chan []Noder)
 		nchan := make(chan Node)
 		schan := make(chan Node)
 		fchan := make(chan Node)
@@ -59,9 +59,9 @@ func TestRegisterNodes(t *testing.T) {
 
 		count := 0
 		for {
-			_, exist1 := blacklist.Node(fn.Id)
+			_, exist1 := blacklist.Node(fn.id)
 			if exist1 {
-				_, exist2 := current.Node(fn.Id)
+				_, exist2 := current.Node(fn.id)
 				if !exist2 {
 					break
 				}
@@ -74,7 +74,13 @@ func TestRegisterNodes(t *testing.T) {
 			count++
 		}
 
-		ochan <- RemovePointers(nodes)
+		noders := []Noder{}
+
+		for _, n := range nodes {
+			noders = append(noders, n)
+		}
+
+		ochan <- noders
 		count = 0
 
 	nodeloop:
@@ -155,8 +161,13 @@ func TestUpdateNodes(t *testing.T) {
 		nodes = append(nodes, nn...)
 		nodeChannel := make(chan Node, tc.newNodeCount)
 		staleChannel := make(chan Node, tc.staleNodeCount)
+		noders := []Noder{}
 
-		bll, cll := updateNodes(RemovePointers(nodes), nodeChannel, staleChannel, blacklist, current)
+		for _, n := range nodes {
+			noders = append(noders, n)
+		}
+
+		bll, cll := updateNodes(noders, nodeChannel, staleChannel, blacklist, current)
 		close(nodeChannel)
 		close(staleChannel)
 
@@ -190,9 +201,9 @@ func TestUpdateNodes(t *testing.T) {
 
 /*************************************************************
 Expected Outcomes:
-- all nodes passed in should be passed out of the out channel
+- all noders passed in should be passed out of the out channel as nodes
 *************************************************************/
-func TestGenerate(t *testing.T) {
+func TestGenerateNoders(t *testing.T) {
 	type test struct {
 		count int
 	}
@@ -211,7 +222,13 @@ func TestGenerate(t *testing.T) {
 
 	for _, tc := range tests {
 		nodes := CreateTestNodes(tc.count, &TestNodeOptions{})
-		out := generate(RemovePointers(nodes)...)
+		noders := []Noder{}
+
+		for _, n := range nodes {
+			noders = append(noders, n)
+		}
+
+		out := generateNoders(noders...)
 
 		count := 0
 		for range out {
@@ -294,9 +311,9 @@ func TestCompareBlackList(t *testing.T) {
 		}
 
 		for _, n := range outNodes {
-			_, exist := blacklist.Node(n.Id)
+			_, exist := blacklist.Node(n.id)
 			if exist {
-				t.Fatalf("node %s was blacklisted but was sent through the out channel", n.Id)
+				t.Fatalf("node %s was blacklisted but was sent through the out channel", n.id)
 			}
 		}
 

--- a/testing.go
+++ b/testing.go
@@ -190,11 +190,11 @@ func NewLocalGRPCClient(target string, bufDialer func(context.Context, string) (
 }
 
 type MockObserver struct {
-	observeChannel chan []Node
+	observeChannel chan []Noder
 	fail           bool
 }
 
-func newMockObserver(ochan chan []Node, fail bool) *MockObserver {
+func newMockObserver(ochan chan []Noder, fail bool) *MockObserver {
 	o := MockObserver{
 		observeChannel: ochan,
 		fail:           fail,
@@ -203,7 +203,7 @@ func newMockObserver(ochan chan []Node, fail bool) *MockObserver {
 	return &o
 }
 
-func (o *MockObserver) Observe() (chan []Node, error) {
+func (o *MockObserver) Observe() (chan []Noder, error) {
 	if o.fail {
 		return nil, errors.New("fail")
 	}


### PR DESCRIPTION
Updates the main entrances of the package so that they either take an interface or native types.  This will allows for external packages to be able to use Courier without dealing with Courier native types.