### PR TITLE
Graceful shutdown of nodes

### DIFF
--- a/client_node.go
+++ b/client_node.go
@@ -14,10 +14,42 @@ type clientNode struct {
 	currentId  string
 }
 
+type ClientNodeDialError struct {
+	Hostname string
+	Port     string
+	Err      error
+}
+
+func (err *ClientNodeDialError) Error() string {
+	return fmt.Sprintf("newClientNode: could not create connection at %s:%s: %s", err.Hostname, err.Port, err.Err)
+}
+
+type ClientNodeSendError struct {
+	Method string
+	Err    error
+}
+
+func (err *ClientNodeSendError) Error() string {
+	return fmt.Sprintf("%s: %s", err.Method, err.Err)
+}
+
+type ClientNodeMessageTypeError struct {
+	Method string
+	Type   messageType
+}
+
+func (err *ClientNodeMessageTypeError) Error() string {
+	return fmt.Sprintf("%s: message must be of type %s", err.Method, err.Type)
+}
+
 func newClientNode(node Node, currrentId string, options ...grpc.DialOption) (*clientNode, error) {
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", node.address, node.port), options...)
 	if err != nil {
-		return nil, fmt.Errorf("could not create connection at %s: %s", fmt.Sprintf("%s:%s", node.address, node.port), err)
+		return nil, &ClientNodeDialError{
+			Err:      err,
+			Port:     node.port,
+			Hostname: node.address,
+		}
 	}
 
 	n := clientNode{
@@ -41,7 +73,10 @@ func (c *clientNode) sendMessage(ctx context.Context, m Message) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error semding message: %s", err)
+		return &ClientNodeSendError{
+			Err:    err,
+			Method: "sendMessage",
+		}
 	}
 
 	return nil
@@ -49,7 +84,10 @@ func (c *clientNode) sendMessage(ctx context.Context, m Message) error {
 
 func (c *clientNode) sendPublishMessage(ctx context.Context, m Message) error {
 	if m.Type != PubMessage {
-		return fmt.Errorf("message type must be of type PublishMessage")
+		return &ClientNodeMessageTypeError{
+			Type:   PubMessage,
+			Method: "sendRequestMessage",
+		}
 	}
 
 	_, err := proto.NewMessageServerClient(c.connection).PublishMessage(ctx, &proto.PublishMessageRequest{
@@ -60,7 +98,10 @@ func (c *clientNode) sendPublishMessage(ctx context.Context, m Message) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not send message: %s", err)
+		return &ClientNodeSendError{
+			Err:    err,
+			Method: "sendPublishMessage",
+		}
 	}
 
 	return nil
@@ -68,7 +109,10 @@ func (c *clientNode) sendPublishMessage(ctx context.Context, m Message) error {
 
 func (c *clientNode) sendRequestMessage(ctx context.Context, m Message) error {
 	if m.Type != ReqMessage {
-		return fmt.Errorf("message type must be of type RequestMessage")
+		return &ClientNodeMessageTypeError{
+			Type:   ReqMessage,
+			Method: "sendRequestMessage",
+		}
 	}
 
 	_, err := proto.NewMessageServerClient(c.connection).RequestMessage(ctx, &proto.RequestMessageRequest{
@@ -80,7 +124,10 @@ func (c *clientNode) sendRequestMessage(ctx context.Context, m Message) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not send message: %s", err)
+		return &ClientNodeSendError{
+			Err:    err,
+			Method: "sendRequestMessage",
+		}
 	}
 
 	return nil
@@ -88,7 +135,10 @@ func (c *clientNode) sendRequestMessage(ctx context.Context, m Message) error {
 
 func (c *clientNode) sendResponseMessage(ctx context.Context, m Message) error {
 	if m.Type != RespMessage {
-		return fmt.Errorf("message type must be of type ResponseMessage")
+		return &ClientNodeMessageTypeError{
+			Type:   RespMessage,
+			Method: "sendResponseMessage",
+		}
 	}
 
 	_, err := proto.NewMessageServerClient(c.connection).ResponseMessage(ctx, &proto.ResponseMessageRequest{
@@ -99,7 +149,10 @@ func (c *clientNode) sendResponseMessage(ctx context.Context, m Message) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not send message: %s", err)
+		return &ClientNodeSendError{
+			Err:    err,
+			Method: "sendResponseMessage",
+		}
 	}
 
 	return nil

--- a/client_node.go
+++ b/client_node.go
@@ -15,13 +15,14 @@ type clientNode struct {
 }
 
 type ClientNodeDialError struct {
+	Method   string
 	Hostname string
 	Port     string
 	Err      error
 }
 
 func (err *ClientNodeDialError) Error() string {
-	return fmt.Sprintf("newClientNode: could not create connection at %s:%s: %s", err.Hostname, err.Port, err.Err)
+	return fmt.Sprintf("%s: could not create connection at %s:%s: %s", err.Method, err.Hostname, err.Port, err.Err)
 }
 
 type ClientNodeSendError struct {
@@ -46,6 +47,7 @@ func newClientNode(node Node, currrentId string, options ...grpc.DialOption) (*c
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", node.address, node.port), options...)
 	if err != nil {
 		return nil, &ClientNodeDialError{
+			Method:   "newClientNode",
 			Err:      err,
 			Port:     node.port,
 			Hostname: node.address,

--- a/client_node_map.go
+++ b/client_node_map.go
@@ -1,12 +1,5 @@
 package courier
 
-type ClientNodeMapper interface {
-	Node(string) (clientNode, bool)
-	Add(clientNode)
-	Remove(string)
-	Length() int
-}
-
 type clientNodeMap struct {
 	nodes map[string]clientNode
 	lock  Locker

--- a/client_node_test.go
+++ b/client_node_test.go
@@ -2,12 +2,62 @@ package courier
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
+
+func TestClientNodeSendError_Error(t *testing.T) {
+	err := fmt.Errorf("test error")
+	method := "testMethod"
+	e := &ClientNodeSendError{
+		Method: method,
+		Err:    err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: %s", method, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: %s", method, err), message)
+	}
+}
+
+func TestClientNodeDialError_Error(t *testing.T) {
+	hostname := "host"
+	port := "8080"
+	err := fmt.Errorf("test error")
+	method := "testMethod"
+	e := &ClientNodeDialError{
+		Method:   method,
+		Hostname: hostname,
+		Port:     port,
+		Err:      err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: could not create connection at %s:%s: %s", method, hostname, port, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: could not create connection at %s:%s: %s", method, hostname, port, err), message)
+	}
+}
+
+func TestClientNodeMessageTypeError_Error(t *testing.T) {
+	mType := PubMessage
+	method := "testMethod"
+	e := &ClientNodeMessageTypeError{
+		Method: method,
+		Type:   mType,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: message must be of type %s", method, mType) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: message must be of type %s", method, mType), message)
+	}
+}
 
 /**************************************************************
 Expected Outcomes:

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package courier
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -9,6 +10,21 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 )
+
+func TestNodeIdGenerationError_Error(t *testing.T) {
+	method := "testMethod"
+	err := fmt.Errorf("test error")
+	e := &NodeIdGenerationError{
+		Method: method,
+		Err:    err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: %s", method, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: %s", method, err), message)
+	}
+}
 
 /**************************************************************
 Expected Outcomes:

--- a/courier_test.go
+++ b/courier_test.go
@@ -219,6 +219,46 @@ func TestCourier_Start(t *testing.T) {
 	}
 }
 
+func Test(t *testing.T) {
+	type test struct {
+		port     string
+		observer Observer
+	}
+
+	tests := []test{
+		{
+			port:     "3000",
+			observer: newMockObserver(make(chan []Noder), false),
+		},
+	}
+
+	for _, tc := range tests {
+		sub := []string{"sub1", "sub2", "sub3"}
+		broad := []string{"broad1", "broad2", "broad3"}
+
+		c, err := NewCourier(
+			WithObserver(newMockObserver(make(chan []Noder), false)),
+			Subscribes(sub...),
+			Broadcasts(broad...),
+			WithHostname("test.com"),
+			WithPort(tc.port),
+			WithDialOptions([]grpc.DialOption{grpc.WithInsecure()}...),
+			WithFailedMessageWaitInterval(time.Second),
+			WithMaxFailedMessageAttempts(5),
+			StartOnCreation(true),
+		)
+		if err != nil {
+			t.Fatalf("expected NewCourier to pass but it failed: %s", err)
+		}
+
+		c.Stop()
+
+		if c.running == true {
+			t.Fatal("expected runnning to be false but it's true")
+		}
+	}
+}
+
 /**************************************************************
 Expected Outcomes:
 - should return an error if the message passed doesn't have a topic registered by client nodes

--- a/courier_test.go
+++ b/courier_test.go
@@ -2,6 +2,7 @@ package courier
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,6 +10,49 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 )
+
+func TestNoObserverError_Error(t *testing.T) {
+	method := "testMethod"
+	e := &NoObserverError{
+		Method: method,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: observer must be set", method) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: observer must be set", method), message)
+	}
+}
+
+func TestSendCourierMessageError_Error(t *testing.T) {
+	err := fmt.Errorf("test error")
+	method := "testMethod"
+	e := &SendCourierMessageError{
+		Method: method,
+		Err:    err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: %s", method, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: %s", method, err), message)
+	}
+}
+
+func TestCourierStartError_Error(t *testing.T) {
+	err := fmt.Errorf("test error")
+	method := "testMethod"
+	e := &CourierStartError{
+		Method: method,
+		Err:    err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: %s", method, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: %s", method, err), message)
+	}
+}
 
 /**************************************************************
 Expected Outcomes:

--- a/courier_test.go
+++ b/courier_test.go
@@ -175,8 +175,6 @@ func TestCourier_Start(t *testing.T) {
 	}
 }
 
-type createMessage func(string, string, []byte) Message
-
 /**************************************************************
 Expected Outcomes:
 - should return an error if the message passed doesn't have a topic registered by client nodes

--- a/node.go
+++ b/node.go
@@ -1,13 +1,5 @@
 package courier
 
-type Noder interface {
-	Id() string
-	Address() string
-	Subscribed() []string
-	Broadcasted() []string
-	Port() string
-}
-
 type Node struct {
 	id                  string
 	address             string

--- a/nodemap.go
+++ b/nodemap.go
@@ -1,14 +1,5 @@
 package courier
 
-type NodeMapper interface {
-	Node(string) (Node, bool)
-	Nodes() map[string]Node
-	Update(...Node)
-	Add(Node)
-	Remove(string)
-	Length() int
-}
-
 type NodeMap struct {
 	nodes map[string]Node
 	lock  Locker

--- a/register.go
+++ b/register.go
@@ -6,6 +6,14 @@ import (
 	"sync"
 )
 
+type Noder interface {
+	Id() string
+	Address() string
+	Subscribed() []string
+	Broadcasted() []string
+	Port() string
+}
+
 type Observer interface {
 	Observe() (chan []Noder, error)
 	AddNode(*Node) error

--- a/responsemap_test.go
+++ b/responsemap_test.go
@@ -1,10 +1,26 @@
 package courier
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 )
+
+func TestUnregisteredResponseError_Error(t *testing.T) {
+	method := "testMethod"
+	messageId := "test"
+	e := &UnregisteredResponseError{
+		Method:    method,
+		MessageId: messageId,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: no response exists with id %s", method, messageId) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: no response exists with id %s", method, messageId), message)
+	}
+}
 
 func TestResponseMap_PushResponse(t *testing.T) {
 	responses := newResponseMap()

--- a/server_test.go
+++ b/server_test.go
@@ -22,6 +22,21 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 	return lis.Dial()
 }
 
+func TestMessageServerStartErrorr_Error(t *testing.T) {
+	method := "testMethod"
+	err := fmt.Errorf("test error")
+	e := &MessageServerStartError{
+		Method: method,
+		Err:    err,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: %s", method, err) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: %s", method, err), message)
+	}
+}
+
 /**************************************************************
 Expected Outcomes:
 - all subject subscribers should receive a message that is assigned that subject

--- a/subscribermap_test.go
+++ b/subscribermap_test.go
@@ -1,10 +1,26 @@
 package courier
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 )
+
+func TestUnregisteredSubscriberError_Error(t *testing.T) {
+	method := "testMethod"
+	subject := "test"
+	e := &UnregisteredSubscriberError{
+		Method:  method,
+		Subject: subject,
+	}
+
+	message := e.Error()
+
+	if message != fmt.Sprintf("%s: no subscribers registered for subject %s", method, subject) {
+		t.Fatalf("expected error message to be %s but got %s", fmt.Sprintf("%s: no subscribers registered for subject %s", method, subject), message)
+	}
+}
 
 /**************************************************************
 Expected Outcomes:


### PR DESCRIPTION
# Description

This adds context to all go routines called that are handled in the courier object.  We gracefully stop the grpc server, stop all gorotuines, wait for goroutines to return with a waitgroup, and close all remaining channels.