### PR TITLE
refactor(client_node): adds functional options for client node

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"sync"
 	"time"
-
-	"google.golang.org/grpc"
 )
 
 type Sender interface {
@@ -43,7 +41,7 @@ func listenForResponseInfo(ctx context.Context, wg *sync.WaitGroup, responseChan
 }
 
 // listenForNewNodes takes nodes passed through a channel and adds them to a NodeMapper and SubMapper
-func listenForNewNodes(ctx context.Context, wg *sync.WaitGroup, nodeChannel chan Node, nodeMap ClientNodeMapper, subMap SubMapper, currentId string, options ...grpc.DialOption) {
+func listenForNewNodes(ctx context.Context, wg *sync.WaitGroup, nodeChannel chan Node, nodeMap ClientNodeMapper, subMap SubMapper, currentId string, options ...ClientNodeOption) {
 	defer wg.Done()
 	for {
 		select {

--- a/client_node_map_test.go
+++ b/client_node_map_test.go
@@ -13,7 +13,7 @@ func TestClientNodeMap_Nodes(t *testing.T) {
 	b := newClientNodeMap()
 
 	for _, n := range nodes {
-		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		cn, err := newClientNode(*n, uuid.NewString(), []ClientNodeOption{WithDialOptions(grpc.WithInsecure())}...)
 		if err != nil {
 			t.Fatalf("could not create client node: %s", err)
 		}
@@ -34,7 +34,7 @@ func TestClientNodeMap_Add(t *testing.T) {
 	nodes := CreateTestNodes(l, &TestNodeOptions{})
 
 	for _, n := range nodes {
-		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		cn, err := newClientNode(*n, uuid.NewString(), []ClientNodeOption{WithDialOptions(grpc.WithInsecure())}...)
 		if err != nil {
 			t.Fatalf("could not create client node: %s", err)
 		}
@@ -54,7 +54,7 @@ func TestClientNodeMap_Remove(t *testing.T) {
 	nodes := CreateTestNodes(l, &TestNodeOptions{})
 
 	for _, n := range nodes {
-		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		cn, err := newClientNode(*n, uuid.NewString(), []ClientNodeOption{WithDialOptions(grpc.WithInsecure())}...)
 		if err != nil {
 			t.Fatalf("could not create client node: %s", err)
 		}
@@ -78,7 +78,7 @@ func TestClientNodeMap_Length(t *testing.T) {
 	nodes := CreateTestNodes(l, &TestNodeOptions{})
 
 	for _, n := range nodes {
-		cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+		cn, err := newClientNode(*n, uuid.NewString(), []ClientNodeOption{WithDialOptions(grpc.WithInsecure())}...)
 		if err != nil {
 			t.Fatalf("could not create client node: %s", err)
 		}

--- a/client_node_test.go
+++ b/client_node_test.go
@@ -67,17 +67,17 @@ Expected Outcomes:
 func TestNewClientNode(t *testing.T) {
 	type test struct {
 		port            string
-		options         []grpc.DialOption
+		options         []ClientNodeOption
 		expectedFailure bool
 	}
 
 	tests := []test{
 		{
-			options:         []grpc.DialOption{grpc.WithInsecure()},
+			options:         []ClientNodeOption{WithDialOptions(grpc.WithInsecure())},
 			expectedFailure: false,
 		},
 		{
-			options:         []grpc.DialOption{},
+			options:         []ClientNodeOption{},
 			expectedFailure: true,
 		},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -107,17 +107,17 @@ Expected Outcomes:
 func TestListenForNewNodes(t *testing.T) {
 	type test struct {
 		newNodes int
-		options  []grpc.DialOption
+		options  []ClientNodeOption
 	}
 
 	tests := []test{
 		{
 			newNodes: 10,
-			options:  []grpc.DialOption{grpc.WithInsecure()},
+			options:  []ClientNodeOption{WithDialOptions(grpc.WithInsecure())},
 		},
 		{
 			newNodes: 100,
-			options:  []grpc.DialOption{grpc.WithInsecure()},
+			options:  []ClientNodeOption{WithDialOptions(grpc.WithInsecure())},
 		},
 	}
 
@@ -427,7 +427,7 @@ func TestIdToClientNodes(t *testing.T) {
 		in := make(chan string)
 		ids := []string{}
 		for _, n := range nodes {
-			cn, err := newClientNode(*n, uuid.NewString(), grpc.WithInsecure())
+			cn, err := newClientNode(*n, uuid.NewString(), WithDialOptions(grpc.WithInsecure()))
 			if err != nil {
 				t.Fatalf("could not create clientNode: %s", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.13
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/magefile/mage v1.11.0
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/mock_client.go
+++ b/mock_client.go
@@ -14,10 +14,7 @@ func NewMockClient(target string, bufDialer func(context.Context, string) (net.C
 		grpc.WithContextDialer(bufDialer),
 		grpc.WithInsecure(),
 	}
-
-	for _, option := range options {
-		mockDialOptions = append(mockDialOptions, option)
-	}
+	mockDialOptions = append(mockDialOptions, options...)
 
 	conn, err := grpc.DialContext(context.Background(), target, mockDialOptions...)
 	if err != nil {


### PR DESCRIPTION
adds functional options to client node so that the actual client implementation is abstracted from calling methods.